### PR TITLE
Add Exception Summaries

### DIFF
--- a/src/ExceptionUnwrapping.jl
+++ b/src/ExceptionUnwrapping.jl
@@ -11,7 +11,10 @@ export unwrap_exception, has_wrapped_exception, is_wrapped_exception,
     summarize_current_exceptions
 
 include("test_throws_wrapped.jl")
-include("exception_summary.jl")
+
+@static if VERSION >= v"1.7.0-"
+    include("exception_summary.jl")
+end
 
 """
     has_wrapped_exception(e, ExceptionType)::Bool

--- a/src/ExceptionUnwrapping.jl
+++ b/src/ExceptionUnwrapping.jl
@@ -7,9 +7,11 @@ module ExceptionUnwrapping
 end ExceptionUnwrapping
 
 export unwrap_exception, has_wrapped_exception, is_wrapped_exception,
-    unwrap_exception_until, unwrap_exception_to_root, @test_throws_wrapped
+    unwrap_exception_until, unwrap_exception_to_root, @test_throws_wrapped,
+    summarize_current_exceptions
 
 include("test_throws_wrapped.jl")
+include("exception_summary.jl")
 
 """
     has_wrapped_exception(e, ExceptionType)::Bool

--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -1,0 +1,98 @@
+###############
+#=
+# TODOs
+- Call it from our codebase
+- Unit tests
+- Seen set, for deduplication
+=#
+
+# Consider adding a _summarize_exception() overload for DistributedException
+#     Pros: less noise
+#     Cons: possibly hiding intermediate exceptions that might have been helpful to see.
+
+const TITLE = "=== THE NEEDLE ==="
+const SEPARATOR = "----------"
+const INDENT_LENGTH = 4
+
+"""
+    summarize_current_exceptions(io::IO=Base.stderr)
+
+Print a summary of the current task's exceptions to `io`.
+
+This is particularly helpful in cases where the exception stack is large, the backtraces are
+large, and CompositeExceptions with multiple parts are involved.
+"""
+function summarize_current_exceptions(io::IO=Base.stderr)
+    printstyled(io, TITLE, '\n'; color=Base.info_color())
+    _summarize_task_exceptions(io, current_task(), 0)
+    return nothing
+end
+
+function _indent_print(io::IO, indent::Int, x...; color=:normal)
+    printstyled(io, " "^indent, x...; color=color)
+end
+
+function _indent_println(io::IO, indent::Int, x...; color=:normal)
+    _indent_print(io, indent, x..., "\n"; color=color)
+end
+
+function _summarize_task_exceptions(io::IO, task::Task, indent::Int)
+    exception_stack = current_exceptions(task)
+    for (i, es) in enumerate(exception_stack)
+        e, stack = es
+        if i != 1
+            # TODO: should the indention increase here?
+            println(io)
+            _indent_println(io, indent, "which caused:"; color=Base.error_color())
+        end
+        _summarize_exception(io, e, stack, indent)
+    end
+end
+
+"""
+    _summarize_exception(io::IO, e::TaskFailedException, _, indent::Int)
+    _summarize_exception(io::IO, e::CompositeException, stack, indent::Int)
+    _summarize_exception(io::IO, e::Exception, stack, indent::Int)
+
+The secret sauce that lets us unwrap TaskFailedExceptions and CompositeExceptions, and
+summarize the actual exception.
+
+TaskFailedException simply wraps a task, so it is just unwrapped, and processed by
+_summarize_task_exceptions().
+
+CompositeException simply wraps a Vector of Exceptions. Each of the individual Exceptions is
+summarized.
+
+All other exceptions are printed via [`Base.showerror()`](@ref). The first stackframe in the
+backtrace is also printed.
+"""
+function _summarize_exception(io::IO, e::TaskFailedException, _, indent::Int)
+    # recurse down the exception stack to find the original exception
+    _summarize_task_exceptions(io, e.task, indent)
+end
+function _summarize_exception(io::IO, e::CompositeException, stack, indent::Int)
+    _indent_println(io, indent, "CompositeException (length ", length(e), "):")
+    for (i, ex) in enumerate(e.exceptions)
+        _summarize_exception(io, ex, stack, indent + INDENT_LENGTH)
+        # print something to separate the multiple exceptions wrapped by CompositeException
+        if i != length(e.exceptions)
+            _indent_println(io, indent + INDENT_LENGTH, SEPARATOR)
+        end
+    end
+end
+# This is the overload that prints the actual exception that occurred.
+function _summarize_exception(io::IO, exc, stack, indent::Int)
+    # Print the exception.
+    _indent_print(io, indent)
+    Base.showerror(io, exc)
+    println(io)
+
+    # Print the source line number of the where the exception occurred.
+    bt = Base.process_backtrace(stack)
+    # borrowed from julia/base/errorshow.jl
+    (frame, n) = bt[1]
+    modulecolordict = copy(Base.STACKTRACE_FIXEDCOLORS)
+    modulecolorcycler = Iterators.Stateful(Iterators.cycle(Base.STACKTRACE_MODULECOLORS))
+    Base.print_stackframe(io, 1, frame, n, indent, modulecolordict, modulecolorcycler)
+    println(io)
+end

--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -10,7 +10,7 @@
 #     Pros: less noise
 #     Cons: possibly hiding intermediate exceptions that might have been helpful to see.
 
-const TITLE = "=== THE NEEDLE ==="
+const TITLE = "=== EXCEPTION SUMMARY ==="
 const SEPARATOR = "----------"
 const INDENT_LENGTH = 4
 

--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -92,7 +92,7 @@ function _summarize_exception(io::IO, e::TaskFailedException, _unused_ ; prefix 
     _summarize_task_exceptions(io, e.task, prefix = prefix)
 end
 function _summarize_exception(io::IO, e::CompositeException, stack; prefix = nothing)
-    _indent_println(io, "CompositeException (length ", length(e), "):", prefix = prefix)
+    _indent_println(io, "CompositeException (", length(e), " tasks):", prefix = prefix)
     io = IOContext(io, :indent => get(io, :indent, 0) + INDENT_LENGTH)
     for (i, ex) in enumerate(e.exceptions)
         _summarize_exception(io, ex, stack; prefix = "$i. ")

--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -11,7 +11,7 @@
 #     Cons: possibly hiding intermediate exceptions that might have been helpful to see.
 
 const TITLE = "=== EXCEPTION SUMMARY ==="
-const SEPARATOR = "----------"
+const SEPARATOR = "--"
 const INDENT_LENGTH = 4
 
 """
@@ -93,12 +93,14 @@ function _summarize_exception(io::IO, e::TaskFailedException, _unused_ ; prefix 
 end
 function _summarize_exception(io::IO, e::CompositeException, stack; prefix = nothing)
     _indent_println(io, "CompositeException (", length(e), " tasks):", prefix = prefix)
-    io = IOContext(io, :indent => get(io, :indent, 0) + INDENT_LENGTH)
+    indent = get(io, :indent, 0)
+    io = IOContext(io, :indent => indent + INDENT_LENGTH)
     for (i, ex) in enumerate(e.exceptions)
         _summarize_exception(io, ex, stack; prefix = "$i. ")
         # print something to separate the multiple exceptions wrapped by CompositeException
         if i != length(e.exceptions)
-            _indent_println(io, SEPARATOR)
+            sep_io = IOContext(io, :indent => indent+1)
+            _indent_println(sep_io, SEPARATOR)
         end
     end
 end

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -92,9 +92,9 @@ end
         str = get_current_exception_string()
     end
 
-    indent = ' '^INDENT_LENGTH
+    sep_indent = ' '^(INDENT_LENGTH-3)
     error_msg = "AssertionError: 1 == 0\n"
-    sep = indent * SEPARATOR * '\n'
+    sep = sep_indent * SEPARATOR * '\n'
     @test occursin("CompositeException (3 tasks):", str)
     # check that message appears thrice
     @test occursin(Regex(" 1. $error_msg(\n|.)*$sep 2. $error_msg(\n|.)*$sep 3. $error_msg"), str)
@@ -171,7 +171,7 @@ throw_multiline(x) = throw(MultiLineException(x))
         )
          [1] throw_multiline(x::Int64)
            @ Main FILE:LINE
-        ----------
+     --
      2. MultiLineException(
             2
         )

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -2,9 +2,7 @@ using Test
 using ExceptionUnwrapping: summarize_current_exceptions, TITLE, INDENT_LENGTH, SEPARATOR
 
 function get_current_exception_string()
-    io = IOBuffer()
-    summarize_current_exceptions(io)
-    str = String(take!(io))
+    str = sprint(summarize_current_exceptions)
     # check this here since it applies to every string
     @test startswith(str, TITLE)
     return str

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -146,14 +146,14 @@ throw_multiline(x) = throw(MultiLineException(x))
         try
             @sync begin
                 Threads.@spawn try
-                    throw_multiline(0)
+                    throw_multiline(0x0)  # use UInt8 for consistent printing in CI
                 catch
-                    throw_multiline(1)
+                    throw_multiline(0x1)
                 end
-                Threads.@spawn throw_multiline(2)
+                Threads.@spawn throw_multiline(0x2)
             end
         catch
-            throw_multiline(3)
+            throw_multiline(0x3)
         end
     catch
         str = get_current_exception_string()
@@ -166,27 +166,27 @@ throw_multiline(x) = throw(MultiLineException(x))
      1. MultiLineException(
             0
         )
-         [1] throw_multiline(x::Int64)
+         [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
 
         which caused:
         MultiLineException(
             1
         )
-         [1] throw_multiline(x::Int64)
+         [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
      --
      2. MultiLineException(
             2
         )
-         [1] throw_multiline(x::Int64)
+         [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
 
     which caused:
     MultiLineException(
         3
     )
-     [1] throw_multiline(x::Int64)
+     [1] throw_multiline(x::UInt8)
        @ Main FILE:LINE
     """
 end

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -1,0 +1,144 @@
+using Test
+using ExceptionUnwrapping: summarize_current_exceptions, TITLE, INDENT_LENGTH, SEPARATOR
+
+function get_current_exception_string()
+    io = IOBuffer()
+    summarize_current_exceptions(io)
+    str = String(take!(io))
+    # check this here since it applies to every string
+    @test startswith(str, TITLE)
+    return str
+end
+
+# Similar to Base.occursin() except this function accepts a count. Requires `count`
+# allocations, so not the most efficient way to check.
+function occursin_n(
+    needle::Union{AbstractString,AbstractPattern,AbstractChar},
+    haystack::AbstractString,
+    count::Int)
+    for _ in 1:count
+        new_haystack = replace(haystack, needle => "", count=1)
+        @test haystack != new_haystack
+        haystack = new_haystack
+    end
+end
+
+@testset "TaskFailedException" begin
+    threw = false
+
+    ch = Channel{Nothing}() do ch
+        @assert false
+        put!(ch, nothing)
+    end
+    try
+        take!(ch)
+    catch
+        str = get_current_exception_string()
+        @test occursin("AssertionError: false", str)
+        threw = true
+    end
+
+    @test threw
+end
+
+@testset "CompositeException" begin
+    threw = false
+
+    try
+        @sync begin
+            Threads.@spawn @assert false
+            Threads.@spawn @assert !true
+            Threads.@spawn @assert true
+        end
+    catch
+        str = get_current_exception_string()
+        @test occursin("CompositeException (length 2):", str)
+        @test occursin("AssertionError: false", str)
+        @test occursin("AssertionError: !true", str)
+        threw = true
+    end
+
+    @test threw
+end
+
+@testset "Chained Causes in TaskFailedException" begin
+    threw = false
+
+    ch = Channel{Nothing}() do ch
+        try
+            @assert false
+            put!(ch, nothing)
+        catch
+            fetch(
+                Threads.@spawn error("INSIDE CATCH BLOCK")
+            )
+        end
+    end
+    try
+        fetch(
+            Threads.@spawn take!(ch)
+        )
+    catch
+        str = get_current_exception_string()
+        @test occursin("AssertionError: false", str)
+        @test occursin("which caused:\nINSIDE CATCH BLOCK", str)
+        threw = true
+    end
+
+    @test threw
+end
+
+@testset "Duplicates" begin
+    threw = false
+
+    try
+        ch = Channel() do ch
+            @assert 1 == 0
+        end
+        @time @sync begin
+            Threads.@spawn take!(ch)
+            Threads.@spawn take!(ch)
+            Threads.@spawn take!(ch)
+        end
+    catch
+        str = get_current_exception_string()
+        indent = ' '^INDENT_LENGTH
+        error_msg = indent * "AssertionError: 1 == 0\n"
+        sep = indent * SEPARATOR * '\n'
+        @test occursin("CompositeException (length 3):", str)
+        # check that message appears thrice
+        @test occursin(Regex("$error_msg(\n|.)*$sep$error_msg(\n|.)*$sep$error_msg"), str)
+        threw = true
+    end
+
+    @test threw
+end
+
+@testset "More caused by" begin
+    threw = false
+
+    try
+        try
+            @sync begin
+                Threads.@spawn try
+                    @assert false
+                catch
+                    @assert 2+2 == 3
+                end
+            end
+        catch
+            @assert 1-1 == 4
+        end
+    catch
+        str = get_current_exception_string()
+        indent = ' '^INDENT_LENGTH
+        error_msg = indent * "AssertionError: 1 == 0\n"
+        @test occursin("CompositeException (length 1):", str)
+        @test occursin("\n$(indent)AssertionError: false\n", str)
+        @test occursin("\n$(indent)which caused:\n$(indent)AssertionError: 2 + 2 == 3\n", str)
+        @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
+        threw = true
+    end
+
+    @test threw
+end

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -22,8 +22,7 @@ function occursin_n(needle, haystack, count::Int)
 end
 
 @testset "TaskFailedException" begin
-    threw = false
-
+    local str
     ch = Channel{Nothing}() do ch
         @assert false
         put!(ch, nothing)
@@ -32,16 +31,13 @@ end
         take!(ch)
     catch
         str = get_current_exception_string()
-        @test occursin("AssertionError: false", str)
-        threw = true
     end
 
-    @test threw
+    @test occursin("AssertionError: false", str)
 end
 
 @testset "CompositeException" begin
-    threw = false
-
+    local str
     try
         @sync begin
             Threads.@spawn @assert false
@@ -50,18 +46,15 @@ end
         end
     catch
         str = get_current_exception_string()
-        @test occursin("CompositeException (length 2):", str)
-        @test occursin("AssertionError: false", str)
-        @test occursin("AssertionError: !true", str)
-        threw = true
     end
 
-    @test threw
+    @test occursin("CompositeException (length 2):", str)
+    @test occursin("AssertionError: false", str)
+    @test occursin("AssertionError: !true", str)
 end
 
 @testset "Chained Causes in TaskFailedException" begin
-    threw = false
-
+    local str
     ch = Channel{Nothing}() do ch
         try
             @assert false
@@ -78,17 +71,14 @@ end
         )
     catch
         str = get_current_exception_string()
-        @test occursin("AssertionError: false", str)
-        @test occursin("which caused:\nINSIDE CATCH BLOCK", str)
-        threw = true
     end
 
-    @test threw
+    @test occursin("AssertionError: false", str)
+    @test occursin("which caused:\nINSIDE CATCH BLOCK", str)
 end
 
 @testset "Duplicates" begin
-    threw = false
-
+    local str
     try
         ch = Channel() do ch
             @assert 1 == 0
@@ -100,21 +90,18 @@ end
         end
     catch
         str = get_current_exception_string()
-        indent = ' '^INDENT_LENGTH
-        error_msg = "AssertionError: 1 == 0\n"
-        sep = indent * SEPARATOR * '\n'
-        @test occursin("CompositeException (length 3):", str)
-        # check that message appears thrice
-        @test occursin(Regex(" 1. $error_msg(\n|.)*$sep 2. $error_msg(\n|.)*$sep 3. $error_msg"), str)
-        threw = true
     end
 
-    @test threw
+    indent = ' '^INDENT_LENGTH
+    error_msg = "AssertionError: 1 == 0\n"
+    sep = indent * SEPARATOR * '\n'
+    @test occursin("CompositeException (length 3):", str)
+    # check that message appears thrice
+    @test occursin(Regex(" 1. $error_msg(\n|.)*$sep 2. $error_msg(\n|.)*$sep 3. $error_msg"), str)
 end
 
 @testset "More caused by" begin
-    threw = false
-
+    local str
     try
         try
             @sync begin
@@ -129,16 +116,14 @@ end
         end
     catch
         str = get_current_exception_string()
-        indent = ' '^INDENT_LENGTH
-        error_msg = indent * "AssertionError: 1 == 0\n"
-        @test occursin("CompositeException (length 1):", str)
-        @test occursin("\n 1. AssertionError: false\n", str)
-        @test occursin("\n    which caused:\n    AssertionError: 2 + 2 == 3\n", str)
-        @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
-        threw = true
     end
 
-    @test threw
+    indent = ' '^INDENT_LENGTH
+    error_msg = indent * "AssertionError: 1 == 0\n"
+    @test occursin("CompositeException (length 1):", str)
+    @test occursin("\n 1. AssertionError: false\n", str)
+    @test occursin("\n    which caused:\n    AssertionError: 2 + 2 == 3\n", str)
+    @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
 end
 
 function replace_file_line(str)

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -48,7 +48,7 @@ end
         str = get_current_exception_string()
     end
 
-    @test occursin("CompositeException (length 2):", str)
+    @test occursin("CompositeException (2 tasks):", str)
     @test occursin("AssertionError: false", str)
     @test occursin("AssertionError: !true", str)
 end
@@ -95,7 +95,7 @@ end
     indent = ' '^INDENT_LENGTH
     error_msg = "AssertionError: 1 == 0\n"
     sep = indent * SEPARATOR * '\n'
-    @test occursin("CompositeException (length 3):", str)
+    @test occursin("CompositeException (3 tasks):", str)
     # check that message appears thrice
     @test occursin(Regex(" 1. $error_msg(\n|.)*$sep 2. $error_msg(\n|.)*$sep 3. $error_msg"), str)
 end
@@ -120,7 +120,7 @@ end
 
     indent = ' '^INDENT_LENGTH
     error_msg = indent * "AssertionError: 1 == 0\n"
-    @test occursin("CompositeException (length 1):", str)
+    @test occursin("CompositeException (1 tasks):", str)
     @test occursin("\n 1. AssertionError: false\n", str)
     @test occursin("\n    which caused:\n    AssertionError: 2 + 2 == 3\n", str)
     @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
@@ -158,7 +158,7 @@ throw_multiline(x) = throw(MultiLineException(x))
     @test replace_file_line(str) === """
     === EXCEPTION SUMMARY ===
 
-    CompositeException (length 2):
+    CompositeException (2 tasks):
      1. MultiLineException(
             0
         )

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -12,10 +12,8 @@ end
 
 # Similar to Base.occursin() except this function accepts a count. Requires `count`
 # allocations, so not the most efficient way to check.
-function occursin_n(
-    needle::Union{AbstractString,AbstractPattern,AbstractChar},
-    haystack::AbstractString,
-    count::Int)
+# (Dropped the type-signature since AbstractPattern isn't available in julia 1.3-)
+function occursin_n(needle, haystack, count::Int)
     for _ in 1:count
         new_haystack = replace(haystack, needle => "", count=1)
         @test haystack != new_haystack

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -92,12 +92,16 @@ end
         str = get_current_exception_string()
     end
 
-    sep_indent = ' '^(INDENT_LENGTH-3)
-    error_msg = "AssertionError: 1 == 0\n"
-    sep = sep_indent * SEPARATOR * '\n'
     @test occursin("CompositeException (3 tasks):", str)
     # check that message appears thrice
-    @test occursin(Regex(" 1. $error_msg(\n|.)*$sep 2. $error_msg(\n|.)*$sep 3. $error_msg"), str)
+    @test occursin(Regex(
+        """
+         1. AssertionError: 1 == 0(\n|.)*
+         --
+         2. AssertionError: 1 == 0(\n|.)*
+         --
+         3. AssertionError: 1 == 0
+        """), str)
 end
 
 @testset "More caused by" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,6 @@ end
 @testset "test_throws_wrapped.jl" begin
     include("test_throws_wrapped.jl")
 end
+@testset "exception_summary.jl" begin
+    include("exception_summary.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ end
 @testset "test_throws_wrapped.jl" begin
     include("test_throws_wrapped.jl")
 end
-@testset "exception_summary.jl" begin
-    include("exception_summary.jl")
+@static if VERSION >= v"1.7.0-"
+    @testset "exception_summary.jl" begin
+        include("exception_summary.jl")
+    end
 end


### PR DESCRIPTION
This PR adds the ability to summarize the current exception. This is especially helpful in cases where there are large exceptions with multiple TaskFailedExceptions and CompositeExceptions wrapping multiple exceptions.

The interface is simple:

```Julia
    summarize_current_exceptions(io::IO=Base.stderr)
```

## Examples:

```julia
julia> begin
           try
               try
                   @sync begin
                       Threads.@spawn try
                           @assert false
                       catch
                           @assert 1 != 1
                       end
                       Threads.@spawn @assert 2 != 2
                   end
               catch
                   @assert 3 != 3
               end
           catch
               summarize_current_exceptions()
           end
       end
```
```
=== EXCEPTION SUMMARY ===

CompositeException (2 tasks):
 1. AssertionError: false
     [1] macro expansion
       @ ./REPL[14]:6 [inlined]

    which caused:
    AssertionError: 1 != 1
     [1] macro expansion
       @ ./REPL[14]:8 [inlined]
 --
 2. AssertionError: 2 != 2
     [1] (::var"#10#12")()
       @ Main ./threadingconstructs.jl:258

which caused:
AssertionError: 3 != 3
 [1] top-level scope
   @ REPL[14]:13
```

## TODOs

- [ ] Test this in a larger codebase that can generate truly HUGE exceptions
- [x] Unit tests (WIP already working on this)
- [ ] Seen set, for deduplication
- [ ] Colorize the exception, not the "caused by"
- [x] Add examples to this description
- [ ] Add ability to pass arbitrary exception rather than only allow current exception