### PR TITLE
Unwrap exceptions before printing in exception summary

### DIFF
--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -111,7 +111,7 @@ function _summarize_exception(io::IO, exc, stack; prefix = nothing)
     # printing just the true exceptions in the summary, not any exception
     # wrappers.
     if is_wrapped_exception(exc)
-        unwrapped = unwrap_exception_to_root(exc)    
+        unwrapped = unwrap_exception(exc)    
         return _summarize_exception(io, unwrapped, stack; prefix)
     end
     # Otherwise, we are at the fully unwrapped exception, now.

--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -108,9 +108,13 @@ end
 function _summarize_exception(io::IO, exc, stack; prefix = nothing)
     indent = get(io, :indent, 0)  # used for print_stackframe
 
-    # Print the exception.
+    # Start by fully unwrapping the exception, so that we are printing just the true
+    # exceptions in the summary, not any exception wrappers.
+    unwrapped = unwrap_exception_to_root(exc)    
+        
+    # Print the unwrapped exception.
     exc_io = IOBuffer()
-    Base.showerror(exc_io, exc)
+    Base.showerror(exc_io, unwrapped)
     seekstart(exc_io)
     # Print all lines of the exception indented.
     _indent_print(io, exc_io; prefix = prefix)

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -1,5 +1,6 @@
 using Test
 using ExceptionUnwrapping: summarize_current_exceptions, TITLE, INDENT_LENGTH, SEPARATOR
+import ExceptionUnwrapping
 
 function get_current_exception_string()
     str = sprint(summarize_current_exceptions)
@@ -128,7 +129,7 @@ end
     @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
 end
 
-function replace_file_line(str)
+function replace_file_line(str::AbstractString)
     replace(str, r"@ Main (\S*)" => "@ Main FILE:LINE")
 end
 
@@ -188,4 +189,63 @@ throw_multiline(x) = throw(MultiLineException(x))
        @ Main FILE:LINE
     """
 end
+
+
+# Custom Wrapped Exception Types
+struct ContextException
+    inner::Exception
+    context_msg::String
+end
+# This entire string should be *ignored* by get_current_exception_string()
+function Base.showerror(io::IO, e::ContextException)
+    print(io, "Caught $(typeof(e.inner)) while $(e.context_msg):\n")
+    Base.showerror(io, e.inner)
+end
+ExceptionUnwrapping.unwrap_exception(e::ContextException) = e.inner
+
+@noinline do_the_assertion1(x) = @assert x === 1
+@noinline do_the_assertion2(x) = @assert x === 2
+@noinline do_the_assertion3(x) = @assert x === 3
+function check_val(x)
+    @sync begin
+        Threads.@spawn try
+            do_the_assertion1(x)
+        catch
+            do_the_assertion2(x)
+        end
+        Threads.@spawn do_the_assertion3(x)
+    end
+end
+
+@testset "wrapped exception" begin
+    str = try
+        try
+            # Do the thing
+            check_val(0)
+        catch e
+            rethrow(ContextException(e, "Performing sync-spawn to 'Do the thing.'"))
+        end
+    catch
+        get_current_exception_string()
+    end
+
+    @test replace_file_line(str) === """
+    === EXCEPTION SUMMARY ===
+
+    CompositeException (2 tasks):
+     1. AssertionError: x === 1
+         [1] do_the_assertion1(x::Int64)
+           @ Main FILE:LINE
+
+        which caused:
+        AssertionError: x === 2
+         [1] do_the_assertion2(x::Int64)
+           @ Main FILE:LINE
+     --
+     2. AssertionError: x === 3
+         [1] do_the_assertion3(x::Int64)
+           @ Main FILE:LINE
+    """
+end
+
 

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -203,9 +203,10 @@ function Base.showerror(io::IO, e::ContextException)
 end
 ExceptionUnwrapping.unwrap_exception(e::ContextException) = e.inner
 
-@noinline do_the_assertion1(x) = @assert x === 1
-@noinline do_the_assertion2(x) = @assert x === 2
-@noinline do_the_assertion3(x) = @assert x === 3
+# (Use uints to have consistent test results across architectures)
+@noinline do_the_assertion1(x) = @assert x === 0x1
+@noinline do_the_assertion2(x) = @assert x === 0x2
+@noinline do_the_assertion3(x) = @assert x === 0x3
 function check_val(x)
     @sync begin
         Threads.@spawn try
@@ -221,7 +222,7 @@ end
     str = try
         try
             # Do the thing
-            check_val(0)
+            check_val(0x0)
         catch e
             rethrow(ContextException(e, "Performing sync-spawn to 'Do the thing.'"))
         end
@@ -233,17 +234,17 @@ end
     === EXCEPTION SUMMARY ===
 
     CompositeException (2 tasks):
-     1. AssertionError: x === 1
-         [1] do_the_assertion1(x::Int64)
+     1. AssertionError: x === 0x01
+         [1] do_the_assertion1(x::UInt8)
            @ Main FILE:LINE
 
         which caused:
-        AssertionError: x === 2
-         [1] do_the_assertion2(x::Int64)
+        AssertionError: x === 0x02
+         [1] do_the_assertion2(x::UInt8)
            @ Main FILE:LINE
      --
-     2. AssertionError: x === 3
-         [1] do_the_assertion3(x::Int64)
+     2. AssertionError: x === 0x03
+         [1] do_the_assertion3(x::UInt8)
            @ Main FILE:LINE
     """
 end


### PR DESCRIPTION
For example, if you have an exception that wraps other exceptions to add calling context, you don't want to include those in these exception summaries; they will be printed when you log the full exception, so you don't want to repeat it.

- [x] Needs tests