### PR TITLE
Support unwrapping a CapturedException

### DIFF
--- a/src/ExceptionUnwrapping.jl
+++ b/src/ExceptionUnwrapping.jl
@@ -111,6 +111,7 @@ unwrap_exception(e) = e
 # TaskFailedExceptions wrap a failed task, which contains the exception that caused it
 # to fail. You can unwrap the exception to discover the root cause of the failure.
 unwrap_exception(e::Base.TaskFailedException) = e.task.exception
+unwrap_exception(e::Base.CapturedException) = e.ex
 
 has_wrapped_exception(::T, ::Type{T}) where T = true
 

--- a/test/ExceptionUnwrapping.jl
+++ b/test/ExceptionUnwrapping.jl
@@ -24,6 +24,11 @@ if VERSION >= v"1.3.0-"
             @test_throws UnwrappedExceptionNotFound{ArgumentError} unwrap_exception_until(e, ArgumentError) isa ErrorException
         end
     end
+    
+    @testset "Wrapped CapturedException" begin
+        e = CapturedException(ErrorException("oh no"), backtrace())
+        @test unwrap_exception(e) == ErrorException("oh no")
+    end
 end
 
 struct MyWrappedException{T}


### PR DESCRIPTION
Captured exception is another type of exception that can wrap other exception, used when we want to preserve the other exceptions stack trace and print it (unlike TaskFailedException, it doesn't rely on having a task that needs to throw).
It'd be nice if we could unwrap this exception too.