### PR TITLE
summary: skip CompositeExceptions of length 1

### DIFF
--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -121,11 +121,9 @@ end
         str = get_current_exception_string()
     end
 
-    indent = ' '^INDENT_LENGTH
-    error_msg = indent * "AssertionError: 1 == 0\n"
-    @test occursin("CompositeException (1 tasks):", str)
-    @test occursin("\n 1. AssertionError: false\n", str)
-    @test occursin("\n    which caused:\n    AssertionError: 2 + 2 == 3\n", str)
+    @test !occursin("CompositeException", str)
+    @test occursin("\nAssertionError: false\n", str)
+    @test occursin("\nwhich caused:\nAssertionError: 2 + 2 == 3\n", str)
     @test occursin("\nwhich caused:\nAssertionError: 1 - 1 == 4\n", str)
 end
 

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -121,6 +121,7 @@ end
         str = get_current_exception_string()
     end
 
+    # Note: The CompositeException is filtered out, since it only has a single child exception.
     @test !occursin("CompositeException", str)
     @test occursin("\nAssertionError: false\n", str)
     @test occursin("\nwhich caused:\nAssertionError: 2 + 2 == 3\n", str)


### PR DESCRIPTION
In cases of deeply nested CompositeExceptions with a single wrapped exception, this reduces the level of indentation by one level for each skipped CompositeException.

---

I anticipate another PR or two coming in the next few days, so perhaps we don't need to release immediately after this is merged?