### PR TITLE
summary: band-aid for missing stacktrace

### DIFF
--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -138,10 +138,16 @@ function _summarize_exception(io::IO, exc, stack; prefix = nothing)
         end
     end
     # Now print just the very first frame we've collected:
-    (frame, n) = bt[1]
-    # borrowed from julia/base/errorshow.jl
-    modulecolordict = copy(Base.STACKTRACE_FIXEDCOLORS)
-    modulecolorcycler = Iterators.Stateful(Iterators.cycle(Base.STACKTRACE_MODULECOLORS))
-    Base.print_stackframe(io, 1, frame, n, indent+1, modulecolordict, modulecolorcycler)
-    println(io)
+    if isempty(bt)
+        # A report was received about bt being a 0-element Vector. It's not clear why the
+        # stacktrace is missing, but this should tide us over in the meantime.
+        _indent_println(io, "no stacktrace available")
+    else
+        (frame, n) = bt[1]
+        # borrowed from julia/base/errorshow.jl
+        modulecolordict = copy(Base.STACKTRACE_FIXEDCOLORS)
+        modulecolorcycler = Iterators.Stateful(Iterators.cycle(Base.STACKTRACE_MODULECOLORS))
+        Base.print_stackframe(io, 1, frame, n, indent+1, modulecolordict, modulecolorcycler)
+        println(io)
+    end
 end


### PR DESCRIPTION
The following error was reported by @vustef:

	│    BoundsError: attempt to access 0-element Vector{Any} at index [1]
	│    Stacktrace:
	│      [1] getindex
	│        @ ./array.jl:924 [inlined]
	│      [2] _summarize_exception(io::IOBuffer, exc::InterruptException, stack::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}; prefix::Nothing)
	│        @ ExceptionUnwrapping ~/.julia/packages/ExceptionUnwrapping/Yl4ht/src/exception_summary.jl:141

It's unclear why the stacktrace is missing, but this PR should prevent another exception from being thrown.

---

I recommend not showing whitespace while reviewing.