### PR TITLE
summary: only show first line of Base.showerror()

### DIFF
--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -122,8 +122,9 @@ function _summarize_exception(io::IO, exc, stack; prefix = nothing)
     exc_io = IOBuffer()
     Base.showerror(exc_io, exc)
     seekstart(exc_io)
-    # Print all lines of the exception indented.
-    _indent_print(io, exc_io; prefix = prefix)
+    # Print only first line since Base.showerror() could output an arbitrarily long error.
+    # The summary is intended to only be a short digest of the actual error.
+    _indent_print(io, readline(exc_io); prefix = prefix)
 
     println(io)
 

--- a/test/exception_summary.jl
+++ b/test/exception_summary.jl
@@ -133,9 +133,13 @@ function replace_file_line(str::AbstractString)
     replace(str, r"@ Main (\S*)" => "@ Main FILE:LINE")
 end
 
-# Exception with multi-line show:
+# Exception with multiple lines
 struct MultiLineException x::Any end
-Base.showerror(io::IO, e::MultiLineException) = print(io, "MultiLineException(\n    $(e.x)\n)")
+function Base.showerror(io::IO, e::MultiLineException)
+    print(io, """MultiLineException($(e.x)):
+        error is $(e.x)
+    such long, many line, wow""")
+end
 
 throw_multiline(x) = throw(MultiLineException(x))
 
@@ -162,29 +166,21 @@ throw_multiline(x) = throw(MultiLineException(x))
     === EXCEPTION SUMMARY ===
 
     CompositeException (2 tasks):
-     1. MultiLineException(
-            0
-        )
+     1. MultiLineException(0):
          [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
 
         which caused:
-        MultiLineException(
-            1
-        )
+        MultiLineException(1):
          [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
      --
-     2. MultiLineException(
-            2
-        )
+     2. MultiLineException(2):
          [1] throw_multiline(x::UInt8)
            @ Main FILE:LINE
 
     which caused:
-    MultiLineException(
-        3
-    )
+    MultiLineException(3):
      [1] throw_multiline(x::UInt8)
        @ Main FILE:LINE
     """


### PR DESCRIPTION
Base.showerror() could print an arbitrarily long exception message. A particularly long message can reduce the utility of the summary since it detracts from the visual cues presented by the summary.

As a stopgap, only print the first line of the exception. This ensures the summary is not spammy, while still showing the (presumptively) key part of the exception.

---

This PR has been filed for the record as a potential idea. It will be immediately closed, and not merged. While particularly long exception messages that (IMO) enter the territory of spammy have been observed, only showing the first line of the exception summary reduces the utility of the summary in many more cases.