### PR TITLE
Thoroughly nospecialize all functions; add no-alloc, no-specialize test.

### DIFF
--- a/src/exception_summary.jl
+++ b/src/exception_summary.jl
@@ -6,6 +6,8 @@
 - Seen set, for deduplication
 =#
 
+@nospecialize
+
 # Consider adding a _summarize_exception() overload for DistributedException
 #     Pros: less noise
 #     Cons: possibly hiding intermediate exceptions that might have been helpful to see.
@@ -110,7 +112,10 @@ function _summarize_exception(io::IO, e::CompositeException, stack; prefix = not
     end
 end
 # This is the overload that prints the actual exception that occurred.
-function _summarize_exception(io::IO, exc, stack; prefix = nothing)
+function _summarize_exception(io::IO, @nospecialize(exc), stack; prefix = nothing)
+    @show exc
+    @show is_wrapped_exception(exc)
+    global EXC = exc
     # First, check that this exception isn't some other kind of user-defined
     # wrapped exception. We want to unwrap this layer as well, so that we are
     # printing just the true exceptions in the summary, not any exception
@@ -156,3 +161,5 @@ function _summarize_exception(io::IO, exc, stack; prefix = nothing)
         println(io)
     end
 end
+
+@specialize


### PR DESCRIPTION
Make sure that _all_ functions in ExceptionUnwrapping are marked nospecialize. We don't want to pay the wasted compilation time at runtime, since these are all going to be called in _exceptional_ cases, certainly not in a hot loop, and because we've seen crashes caused by a stackoverflow in type inference while attempting to specialize the code to handle a StackOverflowException! 😅

This time, we add a unit test to ensure that that these functions do not allocate and do not incur new compilation when called with novel arguments.

This is a follow-up to #6 and #15.