### PR TITLE
Unwrap singular CompositeException

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/ExceptionUnwrapping.jl
+++ b/src/ExceptionUnwrapping.jl
@@ -115,7 +115,7 @@ unwrap_exception(e) = e
 # to fail. You can unwrap the exception to discover the root cause of the failure.
 unwrap_exception(e::Base.TaskFailedException) = e.task.exception
 unwrap_exception(e::Base.CapturedException) = e.ex
-unwrap_exception(e::Base.CompositeException) = length(e) == 1 ? only(e) : e
+unwrap_exception(e::Base.CompositeException) = length(e) == 1 ? first(e) : e
 
 has_wrapped_exception(::T, ::Type{T}) where T = true
 

--- a/src/ExceptionUnwrapping.jl
+++ b/src/ExceptionUnwrapping.jl
@@ -115,6 +115,7 @@ unwrap_exception(e) = e
 # to fail. You can unwrap the exception to discover the root cause of the failure.
 unwrap_exception(e::Base.TaskFailedException) = e.task.exception
 unwrap_exception(e::Base.CapturedException) = e.ex
+unwrap_exception(e::Base.CompositeException) = length(e) == 1 ? only(e) : e
 
 has_wrapped_exception(::T, ::Type{T}) where T = true
 

--- a/test/ExceptionUnwrapping.jl
+++ b/test/ExceptionUnwrapping.jl
@@ -29,6 +29,36 @@ if VERSION >= v"1.3.0-"
         e = CapturedException(ErrorException("oh no"), backtrace())
         @test unwrap_exception(e) == ErrorException("oh no")
     end
+
+    @testset "CompositeException with single exception" begin
+        inner = ErrorException("inner")
+        e = CompositeException([inner])
+        @test is_wrapped_exception(e)
+        @test unwrap_exception(e) === inner
+        @test unwrap_exception_to_root(e) === inner
+        @test has_wrapped_exception(e, ErrorException)
+        @test has_wrapped_exception(e, CompositeException)
+        @test !has_wrapped_exception(e, ArgumentError)
+        @test unwrap_exception_until(e, ErrorException) === inner
+    end
+
+    @testset "CompositeException with multiple exceptions" begin
+        e = CompositeException([ErrorException("a"), ArgumentError("b")])
+        @test !is_wrapped_exception(e)
+        @test unwrap_exception(e) === e
+    end
+
+    @testset "CompositeException from @sync with single task" begin
+        try
+            @sync @async error("inner")
+        catch e
+            @test e isa CompositeException
+            @test is_wrapped_exception(e)
+            @test has_wrapped_exception(e, ErrorException)
+            @test unwrap_exception_to_root(e) isa ErrorException
+            @test (unwrap_exception_to_root(e)::ErrorException).msg === "inner"
+        end
+    end
 end
 
 struct MyWrappedException{T}


### PR DESCRIPTION
A `CompositeException` containing exactly one exception is now considered a wrapped exception, and `unwrap_exception` returns that single contained exception. When it contains multiple exceptions, the behavior is unchanged (returns itself).