### PR TITLE
Update actions/cache from v1 to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
GitHub deprecated `actions/cache` v1/v2 and began hard-failing jobs
that use them as of December 2024. This updates the workflow to v4.

## Notes
The Julia nightly job is failing due to a pre-existing issue unrelated to this PR: the `Threw` constructor in Julia's `Test` stdlib changed in nightly (v1.14) to require `current_exceptions()` instead of `nothing`, which breaks `@test_throws_wrapped`. This same failure would occur on `master`.

Co-authored-by: Claude <noreply@anthropic.com>